### PR TITLE
added DICOM loader to data_loader

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -23,8 +23,12 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 def main(args):
     
     # GPU #
-    print('CUDA? ', torch.cuda.is_available(), ',  Running on GPU: ',torch.cuda.current_device())
-    
+    try:
+        print('CUDA? ', torch.cuda.is_available(), ',  Running on GPU: ', torch.cuda.current_device())
+    except AssertionError as e:  # will be raised if torch was not built with cuda
+        if 'NVIDIA' not in e.args[0]:
+            raise e
+
     # Create directory to save model
     if not os.path.exists(args.model_path):
         os.makedirs(args.model_path)

--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ Root
 **Data_Preproceesing_Open_i.py** has to be placed within Open_i dataset folder to generate .csv file
 
 ## Config file
-**config_template.py** should be renamed **config.py** and updated with system-specific parameters.
+**config_template.py** should be renamed **config.py** and updated with system-specific parameters like file paths.
 
 ## Execution
 ```bash
 $python Main.py
 ```
+
+## Reading DICOM files
+Requires `pydicom`, available on conda-forge and PyPI
+`d = pydicom.dcmread(file_path)` returns `pydicom.dataset.FileDataset` object:
+https://pydicom.github.io/pydicom/dev/reference/generated/pydicom.dataset.FileDataset.html
+
+Use `d.PatientOrientation` or `d.ViewPosition` for orientation metadata.

--- a/config_template.py
+++ b/config_template.py
@@ -6,3 +6,4 @@ _dirname = path.dirname(__file__)
 data_dir = 'absolute path to the images directory'
 vocab_file_path = path.join(_dirname, 'relative path from project root to the pickled vocab file')
 img_report_file = path.join(_dirname, 'relative path from project root to the image report csv file')
+img_extension = '.dcm'  # or '.png'

--- a/data_loader.py
+++ b/data_loader.py
@@ -44,7 +44,7 @@ class OpenI(Dataset):
         image_id = self.data.iloc[idx]['index']
         vocab = self.vocab
 
-        image = Image.open(os.path.join(self.root, path + config.img_extension)).convert('RGB')
+        image = Image.open(os.path.join(self.root, image_id + config.img_extension)).convert('RGB')
         if self.transform:
             image = self.transform(image)
 

--- a/data_loader.py
+++ b/data_loader.py
@@ -5,12 +5,19 @@ Created on Mon Jan 27 15:22:15 2020
 @author: Alan
 """
 
-from PIL import Image
 import pandas as pd
 import os
 from torch.utils.data import Dataset
 import torch
 import nltk
+
+import config
+
+# Choose png or DICOM importer
+if config.img_extension == '.dcm':
+    import dicom_image as Image
+else:
+    from PIL import Image
 
 
 class OpenI(Dataset):
@@ -36,7 +43,7 @@ class OpenI(Dataset):
         caption = self.img_name_report.iloc[idx]['Findings']
         vocab = self.vocab
 
-        image = Image.open(os.path.join(self.root, path + '.png')).convert('RGB')
+        image = Image.open(os.path.join(self.root, path + config.img_extension)).convert('RGB')
         if self.transform:
             image = self.transform(image)
 

--- a/dicom_image.py
+++ b/dicom_image.py
@@ -1,0 +1,17 @@
+from PIL import Image
+import pydicom
+
+
+def open(fp, mode="r"):
+    """
+    Designed to replicate the behavior of `PIL.Image.open`
+
+    Args:
+        fp: file path
+        mode: unused. The only option is 'r'.
+
+    Returns: a PIL image
+
+    """
+    dcm = pydicom.dcmread(fp)
+    return Image.fromarray(dcm.pixel_array)

--- a/preprocessing/Data_Processing_Open_i.py
+++ b/preprocessing/Data_Processing_Open_i.py
@@ -10,8 +10,11 @@ import os
 import xml.etree.ElementTree as ET
 import pandas as pd
 
+import config
+
+
 Img_Findings = {}
-report_path = '../data/ecgen-radiology/'
+report_path = config.data_dir
 for filename in os.listdir(report_path):
     print('Processing {}'.format(filename))
 


### PR DESCRIPTION
## Main
- Added a try block around the cuda status. I don't have cuda as a part of my pytorch build

## config_template
- added a file extension parameter to choose png or DICOM

## data_loader
- added a conditional import to depending on whether you are using png or DICOM
- the configuration file extension is also used to search for the image's filename

## dicom_image
- very basic DICOM image loader. Using the same syntax as `PIL.Image.open(fb)`, returns a `PIL` image.
- expansion will be needed if we want to extract any metadata from the DICOM

## Data_Processing_Open_i
- updated so that it looks for the data from the file specified in the config file.